### PR TITLE
JSON-based key pages

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -47,6 +47,15 @@
 			]
 		}
 	},
+	"ContentHandlers": {
+		"keys":  {
+			"class": "MediaWiki\\Extension\\WantedKeys\\KeysContentHandler",
+			"services": [
+				"ParserFactory",
+				"ParsoidParserFactory"
+			]
+		}
+	},
 	"HookHandlers": {
 		"Hooks": {
 			"class": "MediaWiki\\Extension\\KeyPages\\Hooks"
@@ -55,7 +64,10 @@
 	"Hooks": {
 		"wgQueryPages": "Hooks",
 		"RandomPageQuery": "Hooks",
-		"WantedPages::getQueryInfo": "Hooks"
+		"WantedPages::getQueryInfo": "Hooks",
+		"ContentHandlerDefaultModelFor": "Hooks",
+		"CodeEditorGetPageLanguage": "Hooks"
 	},
+	"callback": "MediaWiki\\Extension\\WantedKeys\\Hooks::onRegistration",
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -49,7 +49,7 @@
 	},
 	"ContentHandlers": {
 		"keys":  {
-			"class": "MediaWiki\\Extension\\WantedKeys\\KeysContentHandler",
+			"class": "MediaWiki\\Extension\\KeyPages\\KeysContentHandler",
 			"services": [
 				"ParserFactory",
 				"ParsoidParserFactory"
@@ -68,6 +68,6 @@
 		"ContentHandlerDefaultModelFor": "Hooks",
 		"CodeEditorGetPageLanguage": "Hooks"
 	},
-	"callback": "MediaWiki\\Extension\\WantedKeys\\Hooks::onRegistration",
+	"callback": "MediaWiki\\Extension\\KeyPages\\Hooks::onRegistration",
 	"manifest_version": 2
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,7 +7,7 @@
 
 	"keypages-desc": "Handles The Apple Wiki's [[Firmware Keys|firmware keys]] database.",
 
-	"keypages-page-content": "{{#invoke:Keys|main}}",
+	"keypages-page-content": "<includeonly>{{#invoke:Keys|main}}</includeonly>",
 
 	"wantedkeys": "Wanted key pages",
 	"wantedkeys-intro": "This is a list of [[Firmware Keys|firmware keys]] that have not yet been filled out. You can help out by [[Decrypting Firmwares|decrypting firmware]] and submitting your results.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,9 @@
 	},
 
 	"keypages-desc": "Handles The Apple Wiki's [[Firmware Keys|firmware keys]] database.",
+
+	"keypages-page-content": "{{#invoke:Keys|main}}",
+
 	"wantedkeys": "Wanted key pages",
 	"wantedkeys-intro": "This is a list of [[Firmware Keys|firmware keys]] that have not yet been filled out. You can help out by [[Decrypting Firmwares|decrypting firmware]] and submitting your results.",
 	"wantedkeys-build": "Build",

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -4,14 +4,23 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\KeyPages;
 
+use MediaWiki\Extension\CodeEditor\Hooks\CodeEditorGetPageLanguageHook;
 use MediaWiki\Hook\RandomPageQueryHook;
 use MediaWiki\Hook\WantedPages__getQueryInfoHook;
+use MediaWiki\Revision\Hook\ContentHandlerDefaultModelForHook;
 use MediaWiki\SpecialPage\Hook\WgQueryPagesHook;
+use MediaWiki\Title\Title;
 
 class Hooks implements
 	WgQueryPagesHook,
 	RandomPageQueryHook,
-	WantedPages__getQueryInfoHook {
+	WantedPages__getQueryInfoHook,
+	ContentHandlerDefaultModelForHook,
+	CodeEditorGetPageLanguageHook {
+
+	public static function onRegistration() {
+		define( 'CONTENT_MODEL_KEYS', 'keys' );
+	}
 
 	/**
 	 * @inheritDoc
@@ -36,6 +45,36 @@ class Hooks implements
 	public function onWantedPages__getQueryInfo( $wantedPages, &$query ) {
 		// Exclude key pages from Special:WantedPages
 		$query[ 'conds' ][] = 'lt_namespace != ' . NS_KEYS;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function onContentHandlerDefaultModelFor( $title, &$model ) {
+		// Use our content model in the Keys namespace by default
+		if ( $title->inNamespace( NS_KEYS ) ) {
+			$model = CONTENT_MODEL_KEYS;
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function onCodeEditorGetPageLanguage(
+		Title $title,
+		?string &$languageCode,
+		string $model,
+		string $format
+	) {
+		if ( $title->hasContentModel( CONTENT_MODEL_KEYS ) ) {
+			$languageCode = 'json';
+			return false;
+		}
+
+		return true;
 	}
 
 }

--- a/includes/KeysContent.php
+++ b/includes/KeysContent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\KeyPages;
+
+use MediaWiki\Content\JsonContent;
+
+class KeysContent extends JsonContent {
+
+	/**
+	 * @param string $text
+	 */
+	public function __construct( $text ) {
+		parent::__construct( $text, CONTENT_MODEL_KEYS );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getWikitextForTransclusion() {
+		return self::getText();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isCountable( $hasLinks = null ) {
+		// Don't count in {{NUMBEROFARTICLES}}
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function isValid() {
+		// TODO
+		return true;
+	}
+
+}

--- a/includes/KeysContentHandler.php
+++ b/includes/KeysContentHandler.php
@@ -49,6 +49,7 @@ class KeysContentHandler extends JsonContentHandler {
 		if ( !$status->isOK() ) {
 			return $content->validate();
 		}
+
 		return $status;
 	}
 
@@ -64,12 +65,6 @@ class KeysContentHandler extends JsonContentHandler {
 
 		$parserOptions = $cpoParams->getParserOptions();
 		$revId = $cpoParams->getRevId();
-
-		// Make sure the module exists
-		$moduleTitle = Title::makeTitleSafe( NS_MODULE, 'Keys' );
-		if ( !$moduleTitle ) {
-			throw new Exception( 'Keys module title is not valid' );
-		}
 
 		// Get parser
 		if ( $parserOptions->getUseParsoid() ) {
@@ -94,7 +89,7 @@ class KeysContentHandler extends JsonContentHandler {
 
 		// Render a wikitext page containing the Scribunto invocation
 		$parserOutput = $parser->parse(
-			'{{#invoke:' . $moduleTitle->getText() . '|main}}',
+			'{{int:keypages-page-content}}',
 			$cpoParams->getPage(),
 			$parserOptions,
 			true,

--- a/includes/KeysContentHandler.php
+++ b/includes/KeysContentHandler.php
@@ -75,17 +75,10 @@ class KeysContentHandler extends JsonContentHandler {
 		if ( $parserOptions->getUseParsoid() ) {
 			$parser = $this->parsoidParserFactory->create();
 			$extraArgs = [ $cpoParams->getPreviousOutput() ];
-			// TODO: Am I meant to get this somehow?
-			$moduleRevId = null;
 		} else {
 			$parser = $this->parserFactory->getInstance();
 			$extraArgs = [];
-			$moduleRevId = $parser->fetchCurrentRevisionRecordOfTitle( $moduleTitle )->getId();
 		}
-
-		// Add transclusion metadata so it appears on Special:WhatLinksHere
-		// TODO: Is this really needed?
-		$parserOutput->addTemplate( $moduleTitle, $moduleTitle->getArticleID(), $moduleRevId );
 
 		// If HTML was not requested, we don't need to do anything
 		if ( !$cpoParams->getGenerateHtml() ) {

--- a/includes/KeysContentHandler.php
+++ b/includes/KeysContentHandler.php
@@ -1,0 +1,114 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace MediaWiki\Extension\KeyPages;
+
+use Exception;
+use MediaWiki\Content\Content;
+use MediaWiki\Content\JsonContentHandler;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Content\ValidationParams;
+use MediaWiki\Parser\ParserFactory;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Parser\Parsoid\ParsoidParserFactory;
+use MediaWiki\Title\Title;
+
+class KeysContentHandler extends JsonContentHandler {
+
+	private ParserFactory $parserFactory;
+	private ParsoidParserFactory $parsoidParserFactory;
+
+	public function __construct(
+		string $modelId,
+		ParserFactory $parserFactory,
+		ParsoidParserFactory $parsoidParserFactory
+	) {
+		parent::__construct($modelId, [ CONTENT_FORMAT_JSON ]);
+		$this->parserFactory = $parserFactory;
+		$this->parsoidParserFactory = $parsoidParserFactory;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getContentClass() {
+		return KeysContent::class;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function validateSave(
+		Content $content,
+		ValidationParams $validationParams
+	) {
+		// @phan-var KeysContent $content
+
+		$status = parent::validateSave( $content, $validationParams );
+		if ( !$status->isOK() ) {
+			return $content->validate();
+		}
+		return $status;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$parserOutput
+	) {
+		// @phan-var KeysContent $content
+
+		$parserOptions = $cpoParams->getParserOptions();
+		$revId = $cpoParams->getRevId();
+
+		// Make sure the module exists
+		$moduleTitle = Title::makeTitleSafe( NS_MODULE, 'Keys' );
+		if ( !$moduleTitle ) {
+			throw new Exception( 'Keys module title is not valid' );
+		}
+
+		// Get parser
+		if ( $parserOptions->getUseParsoid() ) {
+			$parser = $this->parsoidParserFactory->create();
+			$extraArgs = [ $cpoParams->getPreviousOutput() ];
+			// TODO: Am I meant to get this somehow?
+			$moduleRevId = null;
+		} else {
+			$parser = $this->parserFactory->getInstance();
+			$extraArgs = [];
+			$moduleRevId = $parser->fetchCurrentRevisionRecordOfTitle( $moduleTitle )->getId();
+		}
+
+		// Add transclusion metadata so it appears on Special:WhatLinksHere
+		// TODO: Is this really needed?
+		$parserOutput->addTemplate( $moduleTitle, $moduleTitle->getArticleID(), $moduleRevId );
+
+		// If HTML was not requested, we don't need to do anything
+		if ( !$cpoParams->getGenerateHtml() ) {
+			$parserOutput->setRawText( null );
+			return;
+		}
+
+		// Invoke our own validation. If not valid, don't render the page
+		if ( !$content->isValid() ) {
+			$error = wfMessage( 'invalid-json-data' )->parse();
+			$parserOutput->setRawText( $error );
+		}
+
+		// Render a wikitext page containing the Scribunto invocation
+		$parserOutput = $parser->parse(
+			'{{#invoke:' . $moduleTitle->getText() . '|main}}',
+			$cpoParams->getPage(),
+			$parserOptions,
+			true,
+			true,
+			$revId,
+			...$extraArgs
+		);
+	}
+
+}

--- a/includes/SpecialWantedKeys.php
+++ b/includes/SpecialWantedKeys.php
@@ -84,7 +84,6 @@ class SpecialWantedKeys extends WantedQueryPage {
 	 */
 	public function formatResult( $skin, $result ) {
 		$linkRenderer = $this->getLinkRenderer();
-		$lang = $this->getLanguage();
 
 		$html = [];
 		$html[] = '<tr>';


### PR DESCRIPTION
Store key pages as JSON, rather than wikitext, but still render them using Module:Keys.

To do:

* [ ] Extension
  * [ ] Implement schema validation
* [ ] Lua module
  * [ ] Add `2` suffix to HTML ids for 2nd model
  * [ ] Fix handling of 2nd model download links
  * [x] Add link to [docs page](https://theapplewiki.com/wiki/The_Apple_Wiki:Key_pages)
  * [ ] See if we can clean up handling of rootfs and rootfs-beta
  * [ ] See if we can clean up handling of systemos, recoveryos, etc. images
* [ ] Migration script
  * [ ] Fix conversion of `SEPFirmware`
  * [ ] Use a different value than `null` for not encrypted (missing keys in Lua have a value of `nil` - can‘t differentiate from invalid data)
  * [x] Add a field indicating image format (img2, img3, img4)
  * [x] Add a field indicating dmg format (raw, aea)
  * [ ] img3
    * [ ] Consider whether to convert values from hex to base64
  * [ ] img4
    * [ ] Consider whether to convert values from hex to base64
    * [x] Consider whether to merge key and iv to a single combined string (will API clients handle this correctly?)
* [ ] Contact API clients using `action=raw`
  * [ ] wikiproxy
  * [ ] [ipsw](https://github.com/blacktop/ipsw/blob/0a99e3a81252903894e1fdd8e4dda2e10c813103/internal/download/iphonewiki.go) - uses SMW for key data, but parses firmware page tables. We could help them use SMW instead
  * [ ] https://github.com/ei9h7/64-bit-SSH-Ramdisk/blob/3d23bdfbc873176f49aa38594c322057eac77f45/create.sh#L94
  * [ ] https://github.com/Merculous/Bundle-Creation/blob/5c9588c0db6b30adcf395b8d668ae785f3d851cd/bundle_creation/wiki.py#L31